### PR TITLE
Add a shell.nix for nix users to get to a dev env easier

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs.buildPackages; [
+    # lisp
+    sbcl
+
+    # rust
+    cargo
+    rustc
+    clippy
+
+    # sqllogictest dependencies
+    clang
+
+    # endb_server crate's build script requires git
+    git
+  ];
+
+  buildInputs = with pkgs; [
+  ] ++ lib.optional stdenv.isDarwin libiconv;
+
+  packages = with pkgs; [
+    # rust editor tools
+    rustfmt
+    rust-analyzer
+
+    # python for examples and console
+    python311
+  ];
+}


### PR DESCRIPTION
## Description

Added a simple shell.nix file to make it easier for nix users (nixos, nix package manager or nix-darwin) to get a development or a build environment.

## Testing

Tested on a pure nix-shell on:
- [x] Mac OS (nix-darwin)

## Usage

- Install nix
- Run `nix-shell` in the root of the repository. This will drop you into a new shell with all dependencies available in PATH.

## A few notes

- Maintainability: I do not think this will add much maintainance overhead since it only describes dependencies, which do not change very frequently. Also, it would be easier for a nix user to add a missing dependency in an existing shell.nix than to collect all the required dependencies.
- Reproducibility: While nix is known for allowing reproducible builds, a shell.nix alone does not provide this and the version of packages installed will depend on the user's nixpkgs/nixos version. A reproducible build would be best achieved with a flake.

---

Pull Requests are only accepted from signed contributors:

* [x] Read `CONTRIBUTING.md`
* [x] Sign the Endatabas Contributor Agreement

Thank you for your understanding.
